### PR TITLE
Add basic web timer implementation

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Web Timer</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.css
+++ b/src/App.css
@@ -1,42 +1,13 @@
-#root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
+.app {
   text-align: center;
+  padding: 2rem;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+.timer .time {
+  font-size: 4rem;
+  margin-bottom: 1rem;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
+.controls button {
+  margin: 0 0.5rem;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,35 +1,11 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
 import './App.css'
+import Timer from './Timer'
 
-function App() {
-  const [count, setCount] = useState(0)
-
+export default function App() {
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <div className="app">
+      <h1>Web Timer</h1>
+      <Timer />
+    </div>
   )
 }
-
-export default App

--- a/src/Timer.tsx
+++ b/src/Timer.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react'
+
+const INITIAL_TIME = 25 * 60 // 25 minutes
+
+function pad(value: number): string {
+  return value.toString().padStart(2, '0')
+}
+
+export default function Timer() {
+  const [timeLeft, setTimeLeft] = useState(INITIAL_TIME)
+  const [running, setRunning] = useState(false)
+
+  useEffect(() => {
+    if (!running) return
+    if (timeLeft === 0) {
+      setRunning(false)
+      return
+    }
+    const id = setInterval(() => {
+      setTimeLeft((t) => (t > 0 ? t - 1 : 0))
+    }, 1000)
+    return () => clearInterval(id)
+  }, [running, timeLeft])
+
+  const minutes = Math.floor(timeLeft / 60)
+  const seconds = timeLeft % 60
+
+  const start = () => setRunning(true)
+  const pause = () => setRunning(false)
+  const reset = () => {
+    setRunning(false)
+    setTimeLeft(INITIAL_TIME)
+  }
+
+  return (
+    <div className="timer">
+      <div className="time">
+        {pad(minutes)}:{pad(seconds)}
+      </div>
+      <div className="controls">
+        {running ? (
+          <button onClick={pause}>Pause</button>
+        ) : (
+          <button onClick={start}>Start</button>
+        )}
+        <button onClick={reset}>Reset</button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- replace the default Vite page with a simple timer
- add basic timer styles
- set project title to Web Timer

## Testing
- `yarn lint` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6861086fc45483248d6295db76825233