### PR TITLE
Update timer completion highlight

### DIFF
--- a/src/Timer.tsx
+++ b/src/Timer.tsx
@@ -18,26 +18,34 @@ export default function Timer() {
 
   const [timeLeft, setTimeLeft] = useState(initialTime);
   const [running, setRunning] = useState(false);
+  const [finished, setFinished] = useState(false);
 
-  // Highlight when the timer finishes
+  // Highlight when the timer finishes while running
   useEffect(() => {
     const className = "time-up";
-    if (timeLeft === 0) {
+    if (finished) {
       document.body.classList.add(className);
     } else {
       document.body.classList.remove(className);
     }
     return () => document.body.classList.remove(className);
-  }, [timeLeft]);
+  }, [finished]);
+
+  useEffect(() => {
+    if (timeLeft > 0 && finished) {
+      setFinished(false);
+    }
+  }, [timeLeft, finished]);
 
   useEffect(() => {
     if (!running) return;
     if (timeLeft === 0) {
       setRunning(false);
+      setFinished(true);
       return;
     }
     const id = setInterval(() => {
-      setTimeLeft((prevTimeLeft) => (prevTimeLeft > 0 ? prevTimeLeft - 1 : 0));
+      setTimeLeft((prev) => (prev > 0 ? prev - 1 : 0));
     }, 1000);
     return () => clearInterval(id);
   }, [running, timeLeft]);
@@ -69,6 +77,7 @@ export default function Timer() {
   const reset = () => {
     setRunning(false);
     setTimeLeft(INITIAL_TIME);
+    setFinished(false);
   };
 
   const incMinutes = () => {

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,9 @@
 @import "tailwindcss";
 
+body {
+  transition: background-color 0.5s ease;
+}
+
 body.time-up {
   background-color: #e45252;
-  transition: background-color 0.5s ease;
 }


### PR DESCRIPTION
## Summary
- add state to track when timer finishes
- only highlight body when countdown completes
- keep transition on body and fade back on reset

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_686125f5cb7483249fad3eff1a11c299