### PR TITLE
Add timer utility tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --test tests"
   },
   "dependencies": {
     "react": "^19.1.0",

--- a/src/Timer.tsx
+++ b/src/Timer.tsx
@@ -1,5 +1,12 @@
 import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
+import {
+  parseTimerParam,
+  incrementMinutes,
+  decrementMinutes,
+  incrementSeconds,
+  decrementSeconds,
+} from "./timerUtils.js";
 
 const INITIAL_TIME = 10 * 60; // 25 minutes
 
@@ -10,11 +17,7 @@ export default function Timer() {
   const [searchParams] = useSearchParams();
   const timerParam = searchParams.get("timer");
 
-  let initialTime = INITIAL_TIME;
-  if (timerParam) {
-    const [minutes, seconds] = timerParam.split(":").map(Number);
-    initialTime = minutes * 60 + seconds;
-  }
+  const initialTime = parseTimerParam(timerParam, INITIAL_TIME);
 
   const [timeLeft, setTimeLeft] = useState(initialTime);
   const [running, setRunning] = useState(false);
@@ -81,26 +84,16 @@ export default function Timer() {
   };
 
   const incMinutes = () => {
-    setTimeLeft((t) => t + 60);
+    setTimeLeft((t) => incrementMinutes(t));
   };
   const decMinutes = () => {
-    setTimeLeft((t) => (t >= 60 ? t - 60 : 0));
+    setTimeLeft((t) => decrementMinutes(t));
   };
   const incSeconds = () => {
-    setTimeLeft((t) => {
-      const secs = t % 60;
-      const mins = Math.floor(t / 60);
-      const newSecs = secs + 10 > 59 ? 59 : secs + 10;
-      return mins * 60 + newSecs;
-    });
+    setTimeLeft((t) => incrementSeconds(t));
   };
   const decSeconds = () => {
-    setTimeLeft((t) => {
-      const secs = t % 60;
-      const mins = Math.floor(t / 60);
-      const newSecs = secs > 10 ? secs - 10 : 0;
-      return mins * 60 + newSecs;
-    });
+    setTimeLeft((t) => decrementSeconds(t));
   };
 
   return (

--- a/src/timerUtils.js
+++ b/src/timerUtils.js
@@ -1,0 +1,32 @@
+export function parseTimerParam(param, defaultSeconds) {
+  if (!param) return defaultSeconds;
+  const [minutesStr, secondsStr] = param.split(":");
+  const minutes = parseInt(minutesStr, 10);
+  const seconds = parseInt(secondsStr, 10);
+  if (isNaN(minutes) || isNaN(seconds)) {
+    return defaultSeconds;
+  }
+  return minutes * 60 + seconds;
+}
+
+export function incrementMinutes(time) {
+  return time + 60;
+}
+
+export function decrementMinutes(time) {
+  return time >= 60 ? time - 60 : 0;
+}
+
+export function incrementSeconds(time) {
+  const secs = time % 60;
+  const mins = Math.floor(time / 60);
+  const newSecs = secs + 10 > 59 ? 59 : secs + 10;
+  return mins * 60 + newSecs;
+}
+
+export function decrementSeconds(time) {
+  const secs = time % 60;
+  const mins = Math.floor(time / 60);
+  const newSecs = secs > 10 ? secs - 10 : 0;
+  return mins * 60 + newSecs;
+}

--- a/tests/timerUtils.test.js
+++ b/tests/timerUtils.test.js
@@ -1,0 +1,36 @@
+import assert from 'node:assert';
+import test from 'node:test';
+import {
+  parseTimerParam,
+  incrementMinutes,
+  decrementMinutes,
+  incrementSeconds,
+  decrementSeconds,
+} from '../src/timerUtils.js';
+
+test('parseTimerParam parses mm:ss', () => {
+  assert.strictEqual(parseTimerParam('1:30', 0), 90);
+});
+
+test('parseTimerParam handles invalid input', () => {
+  assert.strictEqual(parseTimerParam('bad', 600), 600);
+});
+
+test('incrementMinutes adds 60 seconds', () => {
+  assert.strictEqual(incrementMinutes(10), 70);
+});
+
+test('decrementMinutes subtracts 60 seconds with floor at 0', () => {
+  assert.strictEqual(decrementMinutes(50), 0);
+  assert.strictEqual(decrementMinutes(120), 60);
+});
+
+test('incrementSeconds increases seconds up to 59', () => {
+  assert.strictEqual(incrementSeconds(55), 59);
+  assert.strictEqual(incrementSeconds(40), 50);
+});
+
+test('decrementSeconds decreases seconds not below 0', () => {
+  assert.strictEqual(decrementSeconds(9), 0);
+  assert.strictEqual(decrementSeconds(25), 15);
+});


### PR DESCRIPTION
## Summary
- factor out timer logic into `timerUtils.js`
- use new helpers inside `Timer`
- add node-based tests covering timer utilities
- expose `test` npm script

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686129bc8f288324b9f0d1c450fc0ae7