### PR TITLE
Add help modal

### DIFF
--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+interface ModalProps {
+  show: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+const Modal: React.FC<ModalProps> = ({ show, onClose, children }) => {
+  if (!show) return null;
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50">
+      <div className="bg-white p-6 rounded shadow-md text-center">
+        {children}
+        <button
+          onClick={onClose}
+          className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 mt-4 rounded"
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default Modal;

--- a/src/Timer.tsx
+++ b/src/Timer.tsx
@@ -13,6 +13,7 @@ const INITIAL_TIME = 10 * 60; // 25 minutes
 
 import Button from "./Button";
 import TextBox from "./TextBox";
+import Modal from "./Modal";
 
 export default function Timer() {
   const [searchParams] = useSearchParams();
@@ -23,6 +24,7 @@ export default function Timer() {
   const [timeLeft, setTimeLeft] = useState(initialTime);
   const [running, setRunning] = useState(false);
   const [finished, setFinished] = useState(false);
+  const [showHelp, setShowHelp] = useState(false);
 
   const sendNotification = () => {
     if ("Notification" in window) {
@@ -119,6 +121,9 @@ export default function Timer() {
     setTimeLeft(mins * 60);
   };
 
+  const openHelp = () => setShowHelp(true);
+  const closeHelp = () => setShowHelp(false);
+
   return (
     <div className="timer flex flex-col items-center justify-center p-4 bg-gray-100 rounded-lg shadow-md">
       <h1 className="text-4xl font-bold text-center my-4 text-gray-800">
@@ -156,6 +161,10 @@ export default function Timer() {
         <Button onClick={() => setPreset(5)}>5 min</Button>
         <Button onClick={() => setPreset(10)}>10 min</Button>
       </div>
+      <Button onClick={openHelp}>Help</Button>
+      <Modal show={showHelp} onClose={closeHelp}>
+        <p className="text-lg">URLの末尾に<code>?timer=10:00</code>のように指定できます。</p>
+      </Modal>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add Modal component for simple dialog functionality
- integrate Help button in Timer to show how to set timer via query param

## Testing
- `npm test` *(fails: 0 tests run)*

------
https://chatgpt.com/codex/tasks/task_e_68613049a6108324970263bd08c78b6d